### PR TITLE
biblioteca para a ponte H L298n Mini adicionada

### DIFF
--- a/libraries/core/Motor/ESP32L298nMini/ESP32L298nMini.cpp
+++ b/libraries/core/Motor/ESP32L298nMini/ESP32L298nMini.cpp
@@ -1,0 +1,49 @@
+#include "ESP32L298nMini.h"
+
+// ********** PWM **********
+const uint16_t freq = 1000; 
+
+void ESP32L298nMini::configure(uint8_t in1, uint8_t in2, uint8_t pwmChannel1, uint8_t pwmChannel2, uint8_t resolution){
+    _pinIn1 = in1;
+    _pinIn2 = in2;
+    _pwmChannel1 = pwmChannel1;
+    _pwmChannel2 = pwmChannel2;
+    _resolution = resolution;
+
+    pinMode(_pinIn1,OUTPUT);
+    pinMode(_pinIn2,OUTPUT);
+
+    /* CONFIGURACAO DO PWM */
+    ledcSetup(_pwmChannel1, freq, _resolution);
+    ledcAttachPin(_pinIn1, _pwmChannel1);
+    
+    ledcSetup(_pwmChannel2, freq, _resolution);
+    ledcAttachPin(_pinIn2, _pwmChannel2);
+    
+
+    _maximumPwm = (1 << _resolution)-1; // = (2^_resolution) -1
+
+}
+void ESP32L298nMini::run(int speed) {
+    //pwm limit check
+    if (speed > _maximumPwm){
+        speed = _maximumPwm;
+    }
+    else if ( speed < -_maximumPwm){
+        speed= - _maximumPwm;
+    }
+    
+    if (speed > 0) {
+        ledcWrite(_pwmChannel2, LOW);
+        ledcWrite(_pwmChannel1, speed);
+    } else {
+        speed = -speed;
+        ledcWrite(_pwmChannel1, LOW);
+        ledcWrite(_pwmChannel2, speed);
+    }
+}
+
+void ESP32L298nMini::stop() {
+    ledcWrite(_pwmChannel2, LOW);
+    ledcWrite(_pwmChannel1, LOW);
+}

--- a/libraries/core/Motor/ESP32L298nMini/ESP32L298nMini.h
+++ b/libraries/core/Motor/ESP32L298nMini/ESP32L298nMini.h
@@ -1,0 +1,68 @@
+/********************************************************************
+ * File: ESP32L298nMini.h
+ * Description: A specific C++ library for controlling motors using 
+ *              the L298N Mini  H-bridge driver. Also compatible with 
+ *              other motor drivers that share a similar pin 
+ *              configuration.
+ * Dependencies:
+ *  - Arduino.h
+ * 
+ * Created by: Marllon Batista - November 5, 2024
+********************************************************************/
+
+#ifndef ESP32L298nMini_H 
+#define ESP32L298nMini_H 
+
+#include <Arduino.h>
+
+class ESP32L298nMini {
+  public:
+    /**
+      * @brief Configures the motor control pins and PWM channel.
+      * 
+      * This function sets the direction and pins as outputs 
+      * and initializes the PWM channel using the ledc functions 
+      * (ESP32).
+      * 
+      * @param in1     Pin connected to IN1 (motor direction control)
+      * @param in2     Pin connected to IN2 (motor direction control)
+      * @param pwmChannel1  PWM channel to pin in1
+      * @param pwmChannel2  PWM channel to pin in2
+      * @param resolution   PWM channel resolution
+      * 
+      * @return None
+     */
+    void configure(uint8_t in1, uint8_t in2, uint8_t pwmChannel1, uint8_t pwmChannel2, uint8_t resolution);
+     /**
+     * @brief Runs the motor at the specified speed and direction.
+     * 
+     * Positive values rotate the motor forward, negative values rotate 
+     * it backward, and zero stops the motor. The function automatically 
+     * handles direction logic and PWM writing.
+     * 
+     * @param speed Motor speed 
+     * 
+     * @return None
+     */
+    void run(int speed);
+     /**
+     * @brief Immediately stops the motor (brake mode).
+     * 
+     * Sets both pins to LOW, effectively braking 
+     * the motor.
+     * 
+     * @param None
+     * @return None
+     */
+    void stop();
+ 
+  private:
+    uint8_t _pinIn1;
+    uint8_t _pinIn2;
+    uint8_t _pwmChannel1;//pwm channel to pin in1
+    uint8_t _pwmChannel2;//pwm channel to pin in2
+    uint8_t _resolution;//pwm channel resolution
+    int _maximumPwm;
+    
+};
+#endif

--- a/libraries/core/Motor/ESP32L298nMini/README.md
+++ b/libraries/core/Motor/ESP32L298nMini/README.md
@@ -1,0 +1,72 @@
+# ESP32L298nMini
+
+Uma biblioteca simples em C++ para controle de motores DC usando o driver em ponte H **L298N mini**, compatível também com outros drivers que possuam a mesma pinagem de controle.
+
+Ideal para uso com **ESP32** e outros sistemas embarcados que suportem PWM de forma semalhante a ele.
+
+---
+
+## ⚙️ Funcionalidades
+
+- Suporte a controle de direção e velocidade via PWM
+- Compatível com `ledcWrite()` (ESP32)
+- Abstrai toda a configuração de pinos (`pinMode`, `ledcAttachPin`, etc.)
+- Compatível com drivers com pinos do tipo semelhantes aos da L298N mini
+
+---
+
+## ✅ Compatibilidade
+
+### IDEs testadas
+
+| IDE                 | Status                   |
+| ------------------- | ------------------------ |
+| Arduino IDE         | ✅                       |
+| PlatformIO (VSCode) | ✅ (framework _Arduino_) |
+
+`Legenda: ⚠️ Não testado / ❌ Não compila / ✅ Funciona `
+
+### Microcontroladores testados
+
+| Microcontrolador   | Status                  |
+| ------------------ | ----------------------- |
+| ESP32 (DevKit v1)  | ✅                      |
+| ESP32-S3           | ⚠️ (esperado funcionar) |
+| Arduino UNO / Nano | ❌                      |
+
+`Legenda: ⚠️ Não testado / ❌ Imcompatível / ✅ Funciona `
+
+---
+
+## 📦 Dependências
+
+- [`Arduino.h`](https://docs.arduino.cc/language-reference/pt/)
+- Funções `ledcWrite`, `ledcAttachPin`, `ledcSetup` (para ESP32)
+
+---
+
+## ⚡ Pinagem típica do L298N mini
+
+| Pino do L298N mini    | Conexão sugerida       |
+| --------------------- | ---------------------- |
+| IN1 / IN2 / IN3 / IN4 | GPIO com suporte a PWM |
+
+````
+## 📁 Estrutura
+
+```bash
+Motor/ESP32L298nMini
+├── ESP32L298nMini.h       # Header principal
+├── ESP32L298nMini.cpp     # Implementação
+└── examples/
+    └── ESP32L29nMiniExample.cpp    # Exemplo funcional de uso
+````
+
+## 👨‍💻 Autor
+
+- Criado por: Marllon Batista
+- Data: 5 de novembro de 2024
+
+## 📝 Licença
+
+Este projeto está licenciado sob os termos da licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.

--- a/libraries/core/Motor/ESP32L298nMini/examples/ESP32L29nMiniExample.cpp
+++ b/libraries/core/Motor/ESP32L298nMini/examples/ESP32L29nMiniExample.cpp
@@ -1,0 +1,34 @@
+#include <ESP32L298nMini.h>
+
+// ------------ Motors Instaces and Definitions ----------------//
+ESP32L298nMini motor_r;
+ESP32L298nMini motor_l;
+
+uint8_t motor_l_front = 18;
+uint8_t motor_l_back  = 4;
+uint8_t motor_l_channel1 = 2; //PWM channel for left motor
+uint8_t motor_l_channel2 = 3; //PWM channel for left motor
+
+uint8_t motor_r_front = 21;
+uint8_t motor_r_back  = 19;
+uint8_t motor_r_channel1 = 0; //PWM channel for right motor
+uint8_t motor_r_channel2 = 1; //PWM channel for right motor
+
+uint8_t pwmResolution = 8; //PWM channel resolution
+
+void setup() {
+  motor_l.configure(motor_l_front, motor_l_back , motor_r_channel1, motor_l_channel2,pwmResolution);
+  motor_r.configure(motor_r_front, motor_r_back , motor_r_channel1, motor_r_channel2,pwmResolution);
+}
+
+void loop() {
+  motor_l.run(50);
+  motor_r.run(-50);
+  delay(1000);
+  motor_l.run(-50);
+  motor_r.run(50);
+  delay(1000);
+  motor_l.stop();
+  motor_r.stop();
+  delay(1000);
+}


### PR DESCRIPTION
Esta biblioteca foi criada para facilitar o controle da ponte H L298N Mini utilizando a ESP32. O objetivo é encapsular o controle dos motores DC em uma interface simples e reutilizável dentro do padrão das bibliotecas da GoytaLibs.

✅ Funcionalidades:

 * Inicialização dos pinos de controle. 

 * Controle de rotação (horário/anti-horário).

 * Controle de velocidade via PWM.